### PR TITLE
Add Gaia 3D simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Gaia Galaxy Simulator
 
-This project provides a simple test-particle orbit integration using the `galpy` library in a smooth Milky Way potential. It is meant as a starting point for developing a more realistic galaxy simulator using Gaia data.
+This project provides a simple test-particle orbit integration using the `galpy` library in a smooth Milky Way potential. It also includes a small 3‑D visualisation of real Gaia DR3 stars. The code can serve as a starting point for developing a more realistic galaxy simulator using Gaia data.
 
 ## Requirements
 
 - Python 3.9 or later
-- galpy, numpy, astropy, matplotlib
+- galpy, numpy, astropy, matplotlib, pandas, astroquery
 
 Install the dependencies with pip:
 
-pip install galpy numpy astropy matplotlib
+pip install galpy numpy astropy matplotlib pandas astroquery
 
 Or with conda:
 
-conda install -c conda-forge galpy numpy astropy matplotlib
+conda install -c conda-forge galpy numpy astropy matplotlib pandas astroquery
 
 ## Running
 
@@ -22,6 +22,14 @@ The file `orbit_simulation.py` contains an example of integrating a single test 
 python orbit_simulation.py
 
 It will integrate the orbit for 10 Gyr and plot the orbit in the x–y plane.
+
+The script `gaia_3d_simulator.py` downloads a small sample of stars from Gaia DR3 and shows them in 3‑D Galactocentric coordinates. Run it as:
+
+```bash
+python gaia_3d_simulator.py
+```
+
+The query may take a few seconds as it retrieves data from the online Gaia archive. When finished, a PNG image called `gaia_3d.png` is created in the current directory.
 
 ## Using Visual Studio or VS Code
 

--- a/gaia_3d_simulator.py
+++ b/gaia_3d_simulator.py
@@ -1,0 +1,68 @@
+import matplotlib.pyplot as plt
+from astropy import units as u
+from astropy.coordinates import SkyCoord, Galactocentric
+import requests
+import pandas as pd
+import io
+
+
+GAIA_TAP_SYNC = "https://gea.esac.esa.int/tap-server/tap/sync"
+
+
+def fetch_gaia_data(limit=1000):
+    """Fetch a small sample of Gaia DR3 sources using a synchronous TAP query."""
+    query = (
+        f"SELECT TOP {limit} ra, dec, parallax, pmra, pmdec, radial_velocity "
+        "FROM gaiadr3.gaia_source WHERE parallax > 0"
+    )
+    params = {
+        "REQUEST": "doQuery",
+        "LANG": "ADQL",
+        "FORMAT": "csv",
+        "QUERY": query,
+    }
+    response = requests.post(GAIA_TAP_SYNC, data=params, timeout=60)
+    response.raise_for_status()
+    data = pd.read_csv(io.StringIO(response.text))
+    print(f"Fetched {len(data)} stars from Gaia")
+    return data
+
+
+def convert_to_galactocentric(data):
+    """Convert RA/DEC/parallax to Galactocentric coordinates."""
+    mask = data["parallax"] > 0
+    data = data[mask]
+    c = SkyCoord(
+        ra=data["ra"].values * u.deg,
+        dec=data["dec"].values * u.deg,
+        distance=(1.0 / data["parallax"].values) * u.kpc,
+        pm_ra_cosdec=data["pmra"].values * u.mas / u.yr,
+        pm_dec=data["pmdec"].values * u.mas / u.yr,
+        radial_velocity=data["radial_velocity"].fillna(0).values * u.km / u.s,
+        frame="icrs",
+    )
+    gc = c.transform_to(Galactocentric())
+    return gc
+
+
+def plot_3d_stars(gc):
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    ax.scatter(gc.x, gc.y, gc.z, s=1, alpha=0.5)
+    ax.set_xlabel('X [kpc]')
+    ax.set_ylabel('Y [kpc]')
+    ax.set_zlabel('Z [kpc]')
+    ax.set_title('Gaia DR3 Stars in Galactocentric Coordinates')
+    plt.savefig("gaia_3d.png")
+    plt.close()
+    print("Saved plot to gaia_3d.png")
+
+
+def main():
+    data = fetch_gaia_data()
+    gc = convert_to_galactocentric(data)
+    plot_3d_stars(gc)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `gaia_3d_simulator.py` to fetch a small Gaia DR3 sample and render a 3‑D plot
- save the plot to `gaia_3d.png`
- update README with new instructions and dependencies

## Testing
- `python gaia_3d_simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_6881b099ff3c832f86eebd4e915a77ad