### PR TITLE
Add startup script to show simulation PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ python gaia_3d_simulator.py
 
 The query may take a few seconds as it retrieves data from the online Gaia archive. When finished, a PNG image called `gaia_3d.png` is created in the current directory.
 
+To automatically display the generated image, run the helper script:
+
+```bash
+python start_app.py
+```
+
 ## Using Visual Studio or VS Code
 
 1. Clone this repository and open it in Visual Studio or VS Code.

--- a/gaia_3d_simulator.py
+++ b/gaia_3d_simulator.py
@@ -45,7 +45,7 @@ def convert_to_galactocentric(data):
     return gc
 
 
-def plot_3d_stars(gc):
+def plot_3d_stars(gc, show=False):
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
     ax.scatter(gc.x, gc.y, gc.z, s=1, alpha=0.5)
@@ -54,14 +54,16 @@ def plot_3d_stars(gc):
     ax.set_zlabel('Z [kpc]')
     ax.set_title('Gaia DR3 Stars in Galactocentric Coordinates')
     plt.savefig("gaia_3d.png")
+    if show:
+        plt.show()
     plt.close()
     print("Saved plot to gaia_3d.png")
 
 
-def main():
+def main(show=False):
     data = fetch_gaia_data()
     gc = convert_to_galactocentric(data)
-    plot_3d_stars(gc)
+    plot_3d_stars(gc, show=show)
 
 
 if __name__ == '__main__':

--- a/start_app.py
+++ b/start_app.py
@@ -1,0 +1,4 @@
+from gaia_3d_simulator import main
+
+if __name__ == "__main__":
+    main(show=True)


### PR DESCRIPTION
## Summary
- allow displaying generated PNG in `gaia_3d_simulator.py`
- add `start_app.py` helper script
- document how to run the helper script in README

## Testing
- `python -m py_compile gaia_3d_simulator.py start_app.py orbit_simulation.py`
- `python start_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6881b353c2f0832f95007a0e3de7a883