### PR TITLE
Improve startup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 /.vs/gaia-galaxy-simulator/FileContentIndex/5f85023a-e042-4729-94b9-2d684ebbdafb.vsidx
 /.vs/gaia-galaxy-simulator/FileContentIndex/66b28821-8503-40b3-af9d-98e2e49e8042.vsidx
 /.vs/gaia-galaxy-simulator/FileContentIndex/554fb3e4-cac2-4c04-876d-a0d9952e17f6.vsidx
+# Python build artifacts
+__pycache__/
+*.py[cod]
+# Generated images
+*.png

--- a/start_app.py
+++ b/start_app.py
@@ -1,3 +1,11 @@
+# -*- coding: utf-8 -*-
+"""Helper entry point for running the Gaia 3D simulator.
+
+This file can be set as the startup item in Visual Studio or VS Code. It simply
+imports :func:`main` from :mod:`gaia_3d_simulator` and executes it with
+``show=True`` so that the generated plot window is displayed automatically.
+"""
+
 from gaia_3d_simulator import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- document `start_app.py` as the entry point for Visual Studio and explicitly set UTF‑8 encoding
- ignore build artifacts and generated images

## Testing
- `python3 start_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6881bc57d1d8832f970a6efdd5cbc9bb