### PR TITLE
Add Three.js support for Gaia star visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ python gaia_3d_simulator.py
 
 The query may take a few seconds as it retrieves data from the online Gaia archive. When finished, a PNG image called `gaia_3d.png` is created in the current directory.
 
+The script also writes the star coordinates to `gaia_stars.json` and generates an interactive HTML file `gaia_3d.html` that uses **three.js** for rendering. Open the HTML file in a browser to explore the stars in 3‑D.
+
 To automatically display the generated image, run the helper script:
 
 ```bash


### PR DESCRIPTION
## Summary
- fetch Gaia star samples in random order
- output star coordinates as JSON and generate a basic three.js viewer
- mention the new viewer in the README

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881c6bfe12c832f804bc2a528735fee