### PR TITLE
Improve 3‑D viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ The query may take a few seconds as it retrieves data from the online Gaia archi
 
 The script also writes the star coordinates to `gaia_stars.json` and generates an
 interactive HTML file `gaia_3d.html` that uses **three.js** for rendering. The
-HTML file now embeds the star data directly, so it can be opened locally without
-running a web server. Just open `gaia_3d.html` in a browser to explore the stars
-in 3‑D.
+HTML file embeds the star data directly and now includes **OrbitControls** so you
+can zoom, pan and rotate the view with the mouse. The file can be opened locally
+without running a web server, and it will open automatically when the simulator
+finishes processing.
 
-To automatically display the generated image, run the helper script:
+To automatically display the generated image and open the 3‑D viewer in your
+browser, run the helper script:
 
 ```bash
 python start_app.py

--- a/gaia_3d_simulator.py
+++ b/gaia_3d_simulator.py
@@ -98,6 +98,7 @@ def generate_threejs_html(gc, html_file="gaia_3d.html"):
 </head>
 <body>
 <script src='https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js'></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/controls/OrbitControls.js"></script>
 <script>
 const data = {json_data};
 
@@ -106,6 +107,7 @@ const camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHei
 const renderer = new THREE.WebGLRenderer();
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
+const controls = new THREE.OrbitControls(camera, renderer.domElement);
 
 const geometry = new THREE.BufferGeometry();
 const vertices = [];
@@ -120,6 +122,7 @@ camera.position.z = 2;
 function animate() {{
     requestAnimationFrame(animate);
     points.rotation.y += 0.0005;
+    controls.update();
     renderer.render(scene, camera);
 }}
 animate();
@@ -133,13 +136,16 @@ animate();
     print(f"Saved HTML viewer to {html_file}")
 
 
-def main(show=False):
+def main(show=False, open_browser=False):
     data = fetch_gaia_data()
     gc = convert_to_galactocentric(data)
     save_star_data_json(gc)
     generate_threejs_html(gc)
+    if open_browser:
+        import webbrowser
+        webbrowser.open("gaia_3d.html")
     plot_3d_stars(gc, show=show)
 
 
 if __name__ == "__main__":
-    main()
+    main(open_browser=True)

--- a/start_app.py
+++ b/start_app.py
@@ -9,4 +9,4 @@ imports :func:`main` from :mod:`gaia_3d_simulator` and executes it with
 from gaia_3d_simulator import main
 
 if __name__ == "__main__":
-    main(show=True)
+    main(show=True, open_browser=True)


### PR DESCRIPTION
## Summary
- add zoom and pan to the three.js viewer using OrbitControls
- automatically launch the HTML viewer when processing completes
- update start_app helper and docs

## Testing
- `python -m py_compile gaia_3d_simulator.py start_app.py orbit_simulation.py`
- `python gaia_3d_simulator.py > /tmp/run.log`
- `python start_app.py > /tmp/run2.log`

------
https://chatgpt.com/codex/tasks/task_e_6881cb1de990832f9ca678a2f67be701