### PR TITLE
Add offline-compatible three.js viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ The query may take a few seconds as it retrieves data from the online Gaia archi
 
 The script also writes the star coordinates to `gaia_stars.json` and generates an
 interactive HTML file `gaia_3d.html` that uses **three.js** for rendering. The
-HTML file embeds the star data directly and now includes **OrbitControls** so you
-can zoom, pan and rotate the view with the mouse. The file can be opened locally
-without running a web server, and it will open automatically when the simulator
-finishes processing.
+HTML file embeds the star data directly and inlines the required
+**three.js** libraries (including **OrbitControls**) so you can zoom, pan and
+rotate the view even without an internet connection. The file can be opened
+locally without running a web server and will open automatically when the
+simulator finishes processing.
 
 To automatically display the generated image and open the 3‑D viewer in your
 browser, run the helper script:


### PR DESCRIPTION
## Summary
- inline three.js libraries in the generated HTML
- allow fallback to CDN when download fails
- document the offline viewer capability

## Testing
- `python -m py_compile gaia_3d_simulator.py start_app.py orbit_simulation.py`
- `python start_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6881ce33cbc8832f96e58d70285e5179